### PR TITLE
Add instruction to copy db.env.example to db.env in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ fluxday is engineered based on the concepts of [OKR](https://en.wikipedia.org/wi
 - Analyzing progress and productivity of your company, its departments, teams and employees
 - OAuth server with filtered access to users
 
-Visit the [official website](http://fluxday.io) for more info		
+Visit the [official website](http://fluxday.io) for more info
 
 > “through discipline comes freedom” - aristotle
 
@@ -43,7 +43,7 @@ Please note that the demo will automatically reset every 2 hours.
 
 ### Clone Fluxday
 ```sh
-git clone https://github.com/foradian/fluxday.git  
+git clone https://github.com/foradian/fluxday.git
 ```
 
 ### Install bundler and required gems
@@ -65,6 +65,7 @@ cp config/app_config.yml.example config/app_config.yml
 ```sh
 cp config/database.yml.example config/database.yml
 cp app.env.example app.env
+cp db.env.example db.env
 ```
 Database configurations relies on the file app.env . After above steps update this file with actual credentials.
 


### PR DESCRIPTION
Looks like `db.env` is required for the `fluxday-db` image to build, as indicated on the `docker-compose.yml` file.

Without copying `db.env.example` to `db.env`, I would get this error:

<img width="538" alt="screen shot 2019-01-06 at 4 18 46 pm" src="https://user-images.githubusercontent.com/1557348/50738028-db7fd080-11cf-11e9-95a3-940bf28a1fec.png">

This PR adds an instruction to the README to copy the file.

cc @ismudnx @stpnlr @halissonvit 

Thanks!