### PR TITLE
Update ruby to 2.3 and bundler to 1.17.3 so that they are compatible

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -11,8 +11,8 @@ RUN apt-add-repository ppa:brightbox/ruby-ng
 RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get install -y nodejs \
-    ruby2.1 \
-    ruby2.1-dev \
+    ruby2.3 \
+    ruby2.3-dev \
     build-essential \
     curl \
     zlib1g-dev \
@@ -30,7 +30,7 @@ RUN apt-get install -y nodejs \
     imagemagick \
     wkhtmltopdf
 
-RUN gem install bundler
+RUN gem install bundler -v 1.17.3
 
 ENV APP_HOME /share
 RUN mkdir $APP_HOME

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ fluxday is engineered based on the concepts of [OKR](https://en.wikipedia.org/wi
 - Analyzing progress and productivity of your company, its departments, teams and employees
 - OAuth server with filtered access to users
 
-Visit the [official website](http://fluxday.io) for more info		
+Visit the [official website](http://fluxday.io) for more info
 
 > “through discipline comes freedom” - aristotle
 
@@ -43,7 +43,7 @@ Please note that the demo will automatically reset every 2 hours.
 
 ### Clone Fluxday
 ```sh
-git clone https://github.com/foradian/fluxday.git  
+git clone https://github.com/foradian/fluxday.git
 ```
 
 ### Install bundler and required gems
@@ -94,7 +94,7 @@ docker-compose up -d --build --remove-orphans
 And to access the container:
 
 ```sh
-docker exec -it fluxday /bin/bash
+docker exec -it fluxday-app /bin/bash
 ```
 
 #### 2. Without docker


### PR DESCRIPTION
This pull request contains a couple of adjustments to allow the Docker image of Fluxday to build.

## First error

<img width="889" alt="screen shot 2019-01-06 at 4 30 36 pm" src="https://user-images.githubusercontent.com/1557348/50738288-81ccd580-11d2-11e9-8474-2f72b9934e1f.png">

This issue requires upgrading the version of Ruby to 2.3.

## Second error

<img width="829" alt="screen shot 2019-01-06 at 4 40 40 pm" src="https://user-images.githubusercontent.com/1557348/50738294-8f825b00-11d2-11e9-9cd4-676a3d9449cb.png">

Bundler 2.x was just released and it's not compatible with other packages here, so the solution is to lock it to the highest 1.x version, the 1.17.3.

### Extra

I also noticed that the docker container created was named `fluxday-app`, so I made a change on the README file to reflect it.

cc @ismudnx @stpnlr @halissonvit 