### PR TITLE
Make it buildable by locking the version of Ruby, Bundler, ActiveModel, ActiveRecord, ActiveSupport

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -11,8 +11,8 @@ RUN apt-add-repository ppa:brightbox/ruby-ng
 RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get install -y nodejs \
-    ruby2.1 \
-    ruby2.1-dev \
+    ruby2.3 \
+    ruby2.3-dev \
     build-essential \
     curl \
     zlib1g-dev \
@@ -30,7 +30,7 @@ RUN apt-get install -y nodejs \
     imagemagick \
     wkhtmltopdf
 
-RUN gem install bundler
+RUN gem install bundler -v 1.17.3
 
 ENV APP_HOME /share
 RUN mkdir $APP_HOME

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source 'https://rubygems.org'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '4.0.3'
+#gem 'rails', '4.0.3'
+gem 'rails', '4.0.13'
 
 # Use mysql as the database for Active Record
 gem 'mysql2', '0.3.21'
@@ -32,6 +33,10 @@ group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.
   gem 'sdoc', require: false
 end
+
+gem 'activemodel', '= 4.0.13'
+gem 'activerecord', '= 4.0.13'
+gem 'activesupport', '= 4.0.13'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.1.2'
@@ -69,3 +74,8 @@ gem 'doorkeeper', '1.1.0'
 gem "omniauth-oauth2"#, '1.0.2'
 #gem 'omniauth-fluxapp' , :path => '/home/tp/Desktop/flux'
 gem 'omniauth-fluxapp' , :git  => 'https://github.com/stpnlr/omniauth-fluxapp.git'
+group :production do
+  gem 'puma'
+  gem 'pg'
+  gem 'rails_12factor'
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
 version: '2'
 services:
   docker-fluxday-db:
-    container_name: docker-fluxday-db
+    container_name: fluxday-db
     image: mysql:5.6
     env_file:
       - db.env
 
   docker-fluxday-app:
-    container_name: docker-fluxday-app
+    container_name: fluxday-app
     tty: true
     stdin_open: true
     build:
@@ -18,8 +18,8 @@ services:
     env_file:
       - app.env
     depends_on:
-      - docker-fluxday-db
+      - fluxday-db
     links:
-      - docker-fluxday-db
+      - fluxday-db
     ports:
       - 3000:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
 version: '2'
 services:
-  fluxday-db:
-    container_name: fluxday-db
-    image: mysql
+  docker-fluxday-db:
+    container_name: docker-fluxday-db
+    image: mysql:5.6
     env_file:
       - db.env
 
-  fluxday-app:
-    container_name: fluxday-app
+  docker-fluxday-app:
+    container_name: docker-fluxday-app
     tty: true
     stdin_open: true
     build:
@@ -18,8 +18,8 @@ services:
     env_file:
       - app.env
     depends_on:
-      - fluxday-db
+      - docker-fluxday-db
     links:
-      - fluxday-db
+      - docker-fluxday-db
     ports:
       - 3000:3000


### PR DESCRIPTION
- ruby (2.3) 
- bundler (1.17.3)
- activemodel, activerecord, activesupport (4.0.13)